### PR TITLE
Add .NET 7 support with multi-targeting

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dotnet-version: ['7.0.x', '8.0.x']
 
     steps:
       # Step 1: Checkout the repository
@@ -19,7 +22,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '8.0.x'  # Updated to match your project
+          dotnet-version: ${{ matrix.dotnet-version }}
 
       # Step 3: Restore dependencies
       - name: Restore dependencies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/link-foundation/link-cli/issues/17
+Your prepared branch: issue-17-1bd2fb57
+Your prepared working directory: /tmp/gh-issue-solver-1757514045207
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/link-foundation/link-cli/issues/17
-Your prepared branch: issue-17-1bd2fb57
-Your prepared working directory: /tmp/gh-issue-solver-1757514045207
-
-Proceed.

--- a/Foundation.Data.Doublets.Cli.Tests/Foundation.Data.Doublets.Cli.Tests.csproj
+++ b/Foundation.Data.Doublets.Cli.Tests/Foundation.Data.Doublets.Cli.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFrameworks>net7;net8</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/Foundation.Data.Doublets.Cli/Foundation.Data.Doublets.Cli.csproj
+++ b/Foundation.Data.Doublets.Cli/Foundation.Data.Doublets.Cli.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFrameworks>net7;net8</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackAsTool>true</PackAsTool>
@@ -15,15 +16,15 @@
     <Authors>link-foundation</Authors>
     <Description>A CLI tool for links manipulation.</Description>
     <PackageId>clink</PackageId>
-    <Version>2.2.2</Version>
+    <Version>2.3.0</Version>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/link-foundation/link-cli</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Platform.Data" Version="0.16.1" />
-    <PackageReference Include="Platform.Data.Doublets" Version="0.18.1" />
-    <PackageReference Include="Platform.Data.Doublets.Sequences" Version="0.6.5" />
+    <PackageReference Include="Platform.Data.Doublets" Version="0.17.2" />
+    <PackageReference Include="Platform.Data.Doublets.Sequences" Version="0.5.2" />
     <PackageReference Include="Platform.Protocols.Lino" Version="0.4.5" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- Add support for .NET 7 alongside existing .NET 8 support using multi-targeting
- Update dependencies to versions compatible with .NET 7
- Configure C# 12.0 language version for collection expressions support
- Update CI workflow to test both .NET 7 and 8 frameworks
- Bump version to 2.3.0 to reflect the new feature

## Changes Made
- **Project Configuration**: Updated both main and test projects to target `net7` and `net8`
- **Dependencies**: Downgraded to .NET 7 compatible versions:
  - `Platform.Data.Doublets`: 0.18.1 → 0.17.2
  - `Platform.Data.Doublets.Sequences`: 0.6.5 → 0.5.2
- **Language Version**: Set `LangVersion` to 12.0 for C# collection expressions support
- **CI/CD**: Updated GitHub Actions to test both frameworks using matrix strategy
- **Versioning**: Bumped version from 2.2.2 to 2.3.0

## Test Plan
- [x] Build succeeds for both .NET 7 and .NET 8
- [x] Dependencies resolve correctly for both frameworks
- [x] CI workflow updated to test both targets
- [x] Version updated for next release

**Note**: This implementation uses .NET 7 compatible versions of Platform dependencies. Some newer features from 0.18.x versions may not be available, but this provides the requested .NET 7 support.

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #17